### PR TITLE
🐛 fix(bootstrap): Make --nvim rerun-safe

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -358,9 +358,15 @@ function run_bootstrap {
 	fi
 
 	if args_contain '--nvim'; then
+		nvim_config_path="${XDG_CONFIG_HOME:-$HOME/.config}/nvim"
+
 		print_section 'Starting neovim configuration script'
-		print_action 'Git clone neovim config'
-		try git clone --recursive https://github.com/ladislas/nvim "${XDG_CONFIG_HOME:-$HOME/.config}/nvim"
+		if [ -e "$nvim_config_path" ]; then
+			print_action "Neovim config already exists at $nvim_config_path, skipping clone"
+		else
+			print_action 'Git clone neovim config'
+			try git clone --recursive https://github.com/ladislas/nvim "$nvim_config_path"
+		fi
 	fi
 
 	if args_contain '--data'; then

--- a/scripts/validate_bootstrap.sh
+++ b/scripts/validate_bootstrap.sh
@@ -81,6 +81,35 @@ assert_symlink_target "$SANDBOX_HOME/.local/share/pandoc" "$ROOT_DIR/data/pandoc
 assert_symlink_target "$SANDBOX_HOME/.editorconfig" "$ROOT_DIR/symlink/.editorconfig"
 pass 'all symlinks stable → ok'
 
+section 'Neovim bootstrap rerun safety'
+check 'running bootstrap --nvim twice with a stubbed git clone'
+NVIM_HOME="$WORK_DIR/nvim-home"
+GIT_STUB_DIR="$WORK_DIR/git-stub"
+GIT_STUB_LOG="$WORK_DIR/git-stub.log"
+mkdir -p "$GIT_STUB_DIR"
+cat >"$GIT_STUB_DIR/.zshenv" <<'EOF'
+function git {
+  print -r -- "$*" >>"${GIT_STUB_LOG:?}"
+
+  if [ "$1" = "clone" ]; then
+    mkdir -p "$4"
+    return 0
+  fi
+
+  print -u2 -- "unexpected git invocation: $*"
+  return 1
+}
+EOF
+ZDOTDIR="$GIT_STUB_DIR" GIT_STUB_LOG="$GIT_STUB_LOG" BOOTSTRAP_HOME="$NVIM_HOME" zsh "$ROOT_DIR/bootstrap.sh" --nvim >"$WORK_DIR/nvim-first-run.log" 2>&1
+ZDOTDIR="$GIT_STUB_DIR" GIT_STUB_LOG="$GIT_STUB_LOG" BOOTSTRAP_HOME="$NVIM_HOME" zsh "$ROOT_DIR/bootstrap.sh" --nvim >"$WORK_DIR/nvim-second-run.log" 2>&1
+pass '--nvim succeeded twice → ok'
+
+check 'neovim clone runs only once and second run skips cleanly'
+[ -d "$NVIM_HOME/.config/nvim" ] || fail 'missing neovim checkout after first run'
+[ "$(grep -c '^clone ' "$GIT_STUB_LOG")" -eq 1 ] || fail 'expected exactly one git clone invocation for --nvim'
+grep -q 'Neovim config already exists' "$WORK_DIR/nvim-second-run.log" || fail 'missing skip message on second --nvim run'
+pass '--nvim rerun safety → ok'
+
 section 'Sandbox blocking'
 check '--brew is rejected when BOOTSTRAP_HOME is set'
 if BOOTSTRAP_HOME="$SANDBOX_HOME" zsh "$ROOT_DIR/bootstrap.sh" --brew >"$WORK_DIR/sandbox-block.log" 2>&1; then


### PR DESCRIPTION
Skip cloning when the Neovim config checkout already exists and cover the rerun path in bootstrap validation.
