### PR TITLE
🐛 fix(git): Restore GPG Suite  binary path

### DIFF
--- a/git/config
+++ b/git/config
@@ -23,7 +23,7 @@
 [gpg]
 
 	# ! Install GPG Suite: https://gpgtools.org/ - brew install gpg-suite-no-mail
-	program = gpg
+	program = /usr/local/bin/gpg
 
 [alias]
 


### PR DESCRIPTION
 Changing `program = /usr/local/bin/gpg` to `program = gpg` in caec53a
 caused git to resolve to Homebrew's gnupg (/opt/homebrew/bin/gpg)
 instead of GPG Suite (/usr/local/MacGPG2/bin/gpg2 via /usr/local/bin/gpg).

 GPG Suite ships its own pinentry-mac with Keychain integration, so the
 passphrase is stored once and never prompted again. Homebrew's gnupg
 uses pinentry-curses with no Keychain support, causing a passphrase
 prompt on every new agent session (i.e. after every reboot).

 Revert to the explicit /usr/local/bin/gpg path to restore the previous behaviour.
