### PR TITLE
✨ feat(gpg): Add gpg-agent.conf and wire it into --git bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To instatll them, run the following:
 # swiftlint needs xcode installed
 brew install swiftlint
 
-# mandatory for signing commits
+# mandatory for signing commits — also provides pinentry-mac for Keychain passphrase storage
 brew install --no-quarantine gpg-suite-no-mail
 
 # Formulae

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -353,8 +353,12 @@ function run_bootstrap {
 
 	if args_contain '--git'; then
 		print_section 'Starting git configuration script'
-		print_action 'Symlink config files'
+		print_action 'Symlink git config'
 		try safe_link "$DOTFILES_DIR/git" "${XDG_CONFIG_HOME:-$HOME/.config}/git"
+		print_action 'Symlink GPG agent config'
+		try mkdir -p "$HOME/.gnupg"
+		try chmod 700 "$HOME/.gnupg"
+		try safe_link "$DOTFILES_DIR/gnupg/gpg-agent.conf" "$HOME/.gnupg/gpg-agent.conf"
 	fi
 
 	if args_contain '--nvim'; then

--- a/gnupg/gpg-agent.conf
+++ b/gnupg/gpg-agent.conf
@@ -1,0 +1,10 @@
+# How long (seconds) a cached passphrase stays alive without use
+default-cache-ttl 600
+
+# Hard upper bound on cache lifetime regardless of use
+max-cache-ttl 7200
+
+# Use GPG Suite's pinentry-mac so the passphrase is stored in macOS
+# Keychain and never prompted again after the first unlock.
+# Requires: brew install --no-quarantine gpg-suite-no-mail
+pinentry-program /usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac

--- a/scripts/validate_bootstrap.sh
+++ b/scripts/validate_bootstrap.sh
@@ -36,10 +36,11 @@ assert_symlink_target() {
 
 trap cleanup EXIT
 
-mkdir -p "$SANDBOX_HOME/.config/git" "$SANDBOX_HOME/.local/share/pandoc"
+mkdir -p "$SANDBOX_HOME/.config/git" "$SANDBOX_HOME/.local/share/pandoc" "$SANDBOX_HOME/.gnupg"
 printf 'preexisting git config\n' >"$SANDBOX_HOME/.config/git/config"
 printf 'preexisting pandoc file\n' >"$SANDBOX_HOME/.local/share/pandoc/custom-reference.txt"
 printf 'root = true\n' >"$SANDBOX_HOME/.editorconfig"
+printf 'default-cache-ttl 600\n' >"$SANDBOX_HOME/.gnupg/gpg-agent.conf"
 
 section 'Symlink creation and conflict backup (first run)'
 check 'running bootstrap --git --data --dev with pre-existing files'
@@ -57,6 +58,14 @@ pass '.local/share/pandoc → ok'
 check '.editorconfig is a symlink to the repo symlink/.editorconfig'
 assert_symlink_target "$SANDBOX_HOME/.editorconfig" "$ROOT_DIR/symlink/.editorconfig"
 pass '.editorconfig → ok'
+
+check '.gnupg/gpg-agent.conf is a symlink to the repo gnupg/gpg-agent.conf'
+assert_symlink_target "$SANDBOX_HOME/.gnupg/gpg-agent.conf" "$ROOT_DIR/gnupg/gpg-agent.conf"
+pass '.gnupg/gpg-agent.conf → ok'
+
+check 'conflicting gpg-agent.conf target was backed up'
+find "$SANDBOX_HOME/.gnupg/.bootstrap-backup" -name 'gpg-agent.conf.*' | grep -q . || fail 'missing backup for conflicting gpg-agent.conf target'
+pass 'gpg-agent.conf backup → ok'
 
 check 'conflicting git target was backed up'
 find "$SANDBOX_HOME/.config/.bootstrap-backup" -name 'git.*' | grep -q . || fail 'missing backup for conflicting git target'
@@ -79,6 +88,7 @@ check 'symlinks still correct after second run'
 assert_symlink_target "$SANDBOX_HOME/.config/git" "$ROOT_DIR/git"
 assert_symlink_target "$SANDBOX_HOME/.local/share/pandoc" "$ROOT_DIR/data/pandoc"
 assert_symlink_target "$SANDBOX_HOME/.editorconfig" "$ROOT_DIR/symlink/.editorconfig"
+assert_symlink_target "$SANDBOX_HOME/.gnupg/gpg-agent.conf" "$ROOT_DIR/gnupg/gpg-agent.conf"
 pass 'all symlinks stable → ok'
 
 section 'Neovim bootstrap rerun safety'


### PR DESCRIPTION
GPG Suite ships pinentry-mac which stores the passphrase in the macOS
Keychain, meaning you are only prompted once. Without pinentry-program
set, gpg-agent falls back to pinentry-curses (in-memory cache only)
and re-prompts after every reboot.

- Add gnupg/gpg-agent.conf pointing at GPG Suite's pinentry-mac
- Symlink it to ~/.gnupg/gpg-agent.conf via the --git bootstrap step
- Validate symlink creation, conflict backup, and idempotency in
  validate_bootstrap.sh
- Update README to clarify why gpg-suite-no-mail is required
